### PR TITLE
Always read from connection

### DIFF
--- a/internal/messages/messages.go
+++ b/internal/messages/messages.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/OpenSourceOptimist/skyflow/internal/event"
 	"github.com/OpenSourceOptimist/skyflow/internal/slice"
@@ -166,18 +165,91 @@ type DebugLogger interface {
 	Debug(msg string, keyVals ...interface{})
 }
 
+func errorMsgf(format string, a ...any) WebsocketMessage {
+	return WebsocketMessage{Err: fmt.Errorf(format, a...)}
+}
+
+func parseWebsocketMsg(ctx context.Context, socketMsgType websocket.MessageType, data []byte) WebsocketMessage {
+	if socketMsgType != websocket.MessageText {
+		return errorMsgf("unexpected message type: %d", socketMsgType)
+	}
+	var message []json.RawMessage
+	err := json.Unmarshal(data, &message)
+	if err != nil {
+		return errorMsgf("unmarshal message: %w: %s", err, data)
+	}
+	if len(message) == 0 {
+		return errorMsgf("empty message")
+	}
+	var msgType string
+	err = json.Unmarshal(message[0], &msgType)
+	if err != nil {
+		return errorMsgf("unmarshalling message type: %w", err)
+	}
+	switch msgType {
+	case "EVENT":
+		if len(message) != 2 {
+			return errorMsgf("wrong event length: %s", string(data))
+		}
+		var e event.Event
+		err := json.Unmarshal(message[1], &e)
+		if err != nil {
+			return errorMsgf("unmarshal event message: %s", string(data))
+		}
+		err = event.VerifyEvent(e)
+		if err != nil {
+			return errorMsgf("event verification: %w", err)
+		}
+		return WebsocketMessage{MsgType: EVENT, Value: e}
+	case "REQ":
+		if len(message) < 3 {
+			return errorMsgf("wrong event request lenght: %s", string(data))
+		}
+		var subID SubscriptionID
+		err := json.Unmarshal(message[1], &subID)
+		if err != nil {
+			return errorMsgf("unmatshal sub id: %w", err)
+		}
+		subscription := Subscription{ID: subID}
+		filters := make([]Filter, 0, len(message[2:]))
+		for _, element := range message[2:] {
+			var filter Filter
+			err := json.Unmarshal(element, &filter)
+			if err != nil {
+				return errorMsgf("unmarshal request message: %s", string(data))
+			}
+			filters = append(filters, filter)
+		}
+		subscription.Filters = filters
+		return WebsocketMessage{MsgType: REQ, Value: subscription}
+	case "CLOSE":
+		if len(message) != 2 {
+			return errorMsgf("wrong close message lenght: %s", string(data))
+		}
+		var subscriptionID SubscriptionID
+		err := json.Unmarshal(message[1], &subscriptionID)
+		if err != nil {
+			return errorMsgf("unmatshal sub id: %w", err)
+		}
+		return WebsocketMessage{MsgType: CLOSE, Value: subscriptionID}
+	default:
+		return errorMsgf("unknown msg type: %s", msgType)
+	}
+}
+
 func ListenForMessages(ctx context.Context, r MessageReader, l DebugLogger) <-chan WebsocketMessage {
 	result := make(chan WebsocketMessage)
 	go func() {
 		for {
 			err := ctx.Err()
 			if err != nil {
-				result <- WebsocketMessage{Err: fmt.Errorf("context cancelled: %w", err)}
 				return
 			}
+			// You must always read from the
+			// connection. Otherwise control frames will
+			// not be handled. See Reader and CloseRead
 			socketMsgType, data, err := r.Read(ctx)
 			if err != nil {
-				l.Debug("read error: " + err.Error())
 				if strings.Contains(err.Error(), "WebSocket closed") {
 					return
 				}
@@ -190,92 +262,13 @@ func ListenForMessages(ctx context.Context, r MessageReader, l DebugLogger) <-ch
 				if strings.Contains(err.Error(), "EOF") {
 					return
 				}
-				result <- WebsocketMessage{Err: fmt.Errorf("websocket read error: %w", err)}
-				// TODO: this should probably be exponential in some smart way
-				time.Sleep(100 * time.Millisecond)
-				continue
-			}
-			l.Debug(string(data))
-			if socketMsgType != websocket.MessageText {
-				result <- WebsocketMessage{Err: fmt.Errorf("unexpected message type: %d", socketMsgType)}
-				continue
-			}
-			var message []json.RawMessage
-			err = json.Unmarshal(data, &message)
-			if err != nil {
-				result <- WebsocketMessage{Err: fmt.Errorf("unmarshal message: %w: %s", err, data)}
-				continue
-			}
-			if len(message) == 0 {
-				result <- WebsocketMessage{Err: fmt.Errorf("empty message")}
-				continue
-			}
-			var msgType string
-			err = json.Unmarshal(message[0], &msgType)
-			if err != nil {
-				result <- WebsocketMessage{Err: fmt.Errorf("unmarshalling message type: %w", err)}
-				continue
-			}
-			switch msgType {
-			case "EVENT":
-				if len(message) != 2 {
-					result <- WebsocketMessage{Err: fmt.Errorf("wrong event length: %s", string(data))}
-					continue
-				}
-				var e event.Event
-				err := json.Unmarshal(message[1], &e)
-				if err != nil {
-					result <- WebsocketMessage{Err: fmt.Errorf("unmarshal event message: %s", string(data))}
-					continue
-				}
-				err = event.VerifyEvent(e)
-				if err != nil {
-					result <- WebsocketMessage{Err: fmt.Errorf("event verification: %w", err)}
-					continue
-				}
-				go func(eventToSend event.Event) {
-					result <- WebsocketMessage{MsgType: EVENT, Value: eventToSend}
-				}(e)
-			case "REQ":
-				if len(message) < 3 {
-					result <- WebsocketMessage{Err: fmt.Errorf("wrong event request lenght: %s", string(data))}
-					continue
-				}
-				var subID SubscriptionID
-				err = json.Unmarshal(message[1], &subID)
-				if err != nil {
-					result <- WebsocketMessage{Err: fmt.Errorf("unmatshal sub id: %w", err)}
-					continue
-				}
-				subscription := Subscription{ID: subID}
-				filters := make([]Filter, 0, len(message[2:]))
-				for _, element := range message[2:] {
-					var filter Filter
-					err := json.Unmarshal(element, &filter)
-					if err != nil {
-						result <- WebsocketMessage{Err: fmt.Errorf("unmarshal request message: %s", string(data))}
-						continue //TODO: bug alert
-					}
-					filters = append(filters, filter)
-				}
-				subscription.Filters = filters
-				go func(sub Subscription) {
-					result <- WebsocketMessage{MsgType: REQ, Value: sub}
-				}(subscription)
-			case "CLOSE":
-				if len(message) != 2 {
-					result <- WebsocketMessage{Err: fmt.Errorf("wrong close message lenght: %s", string(data))}
-					continue
-				}
-				var subscriptionID SubscriptionID
-				err = json.Unmarshal(message[1], &subscriptionID)
-				if err != nil {
-					result <- WebsocketMessage{Err: fmt.Errorf("unmatshal sub id: %w", err)}
-					continue
-				}
-				go func(subID SubscriptionID) {
-					result <- WebsocketMessage{MsgType: CLOSE, Value: subID}
-				}(subscriptionID)
+				go func() {
+					result <- errorMsgf("read error %w", err)
+				}()
+			} else {
+				go func(t websocket.MessageType, d []byte) {
+					result <- parseWebsocketMsg(ctx, t, d)
+				}(socketMsgType, data)
 			}
 		}
 	}()

--- a/test/benchmark/main.go
+++ b/test/benchmark/main.go
@@ -11,7 +11,7 @@ import (
 func main() {
 	t := &PanicTestingT{}
 	ctx := context.Background()
-	conn, closer := help.NewSocket(ctx, t, help.WithURI("wss://relay.nostry.eu"))
+	conn, _, closer := help.NewSocket(ctx, t, help.WithURI("wss://relay.nostry.eu"))
 	defer closer()
 	count := 200
 	before := time.Now()

--- a/test/component/main_test.go
+++ b/test/component/main_test.go
@@ -84,7 +84,8 @@ func TestMain(m *testing.M) {
 	}
 	err = pool.Retry(func() error {
 		t := ErrTestingT{}
-		_, _ = help.NewSocket(ctx, &t)
+		_, _, closer := help.NewSocket(ctx, &t)
+		closer()
 		return t.err
 	})
 	if err != nil {

--- a/test/component/nip01_test.go
+++ b/test/component/nip01_test.go
@@ -19,7 +19,7 @@ func TestNIP01BasicFlow(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
-	conn, closer := help.NewSocket(ctx, t)
+	conn, read, closer := help.NewSocket(ctx, t)
 	defer closer()
 
 	testEvent := help.Event(t, help.EventOptions{})
@@ -33,12 +33,7 @@ func TestNIP01BasicFlow(t *testing.T) {
 	require.NoError(t, conn.Write(ctx, websocket.MessageText, reqBytes))
 
 	timeout := time.After(time.Second)
-	for {
-		msgType, responseBytes, err := conn.Read(ctx)
-		require.NoError(t, err)
-		require.Equal(t, websocket.MessageText, msgType)
-		//fmt.Printf("got message: %s\n", string(responseBytes))
-
+	for responseBytes := range read {
 		var eventDataMsg []json.RawMessage
 		require.NoError(t, json.Unmarshal(responseBytes, &eventDataMsg))
 		var recivedMsgType string
@@ -59,7 +54,7 @@ func TestNIP01Closing(t *testing.T) {
 	validEvent := help.Event(t, help.EventOptions{})
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	conn, closer := help.NewSocket(ctx, t)
+	conn, read, closer := help.NewSocket(ctx, t)
 	defer closer()
 	subID1, sub1Closer := help.RequestSub(ctx, t, conn, messages.Filter{IDs: []event.ID{validEvent.ID}})
 	defer sub1Closer()
@@ -67,9 +62,8 @@ func TestNIP01Closing(t *testing.T) {
 	help.Publish(ctx, t, validEvent, conn)
 	subID2, sub2Closer := help.RequestSub(ctx, t, conn, messages.Filter{IDs: []event.ID{validEvent.ID}})
 	defer sub2Closer()
-	sub, e, err := help.ReadEvent(ctx, t, conn)
-	require.NoError(t, err)
-	require.Equal(t, subID2, sub)
+	e, found := help.ReadEvent(ctx, t, read, subID2, time.Second)
+	require.True(t, found)
 	require.Equal(t, e.ID, e.ID)
 }
 
@@ -188,7 +182,7 @@ func TestNIP01Filters(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
-			conn, closer := help.NewSocket(ctx, t)
+			conn, read, closer := help.NewSocket(ctx, t)
 			defer closer()
 			for _, e := range tc.allEvents {
 				help.Publish(ctx, t, e, conn)
@@ -212,7 +206,7 @@ func TestNIP01Filters(t *testing.T) {
 			sub, subCloser := help.RequestSub(ctx, t, conn, modifiedFilters...)
 			defer subCloser()
 			reciviedEvents := slice.ReadSlice(
-				help.ListenForEventsOnSub(ctx, t, conn, sub),
+				help.ListenForEventsOnSub(ctx, t, read, sub, time.Second),
 				len(expectedRecivedEventsIDs),
 				time.Second,
 			)
@@ -230,41 +224,34 @@ func TestNIP01Filters(t *testing.T) {
 func TestNIP01GetEventsAfterInitialSync(t *testing.T) {
 	priv, pub := help.NewKeyPair(t)
 	ctx := context.Background()
-	conn1, closer1 := help.NewSocket(ctx, t)
+	conn1, _, closer1 := help.NewSocket(ctx, t)
 	defer closer1()
 	initialPublishedEvent := help.Event(t, help.EventOptions{PrivKey: priv, Content: "hello world"})
 	help.Publish(ctx, t, initialPublishedEvent, conn1)
 	_, found := help.GetEvent(ctx, t, initialPublishedEvent.ID, time.Second)
 	require.True(t, found)
 
-	conn2, closer2 := help.NewSocket(ctx, t)
+	conn2, read2, closer2 := help.NewSocket(ctx, t)
 	defer closer2()
 	subID, subCloser := help.RequestSub(ctx, t, conn2, messages.Filter{Authors: []event.PubKey{pub}})
 	defer subCloser()
-	subEvents := help.ListenForEventsOnSub(ctx, t, conn2, subID)
-	select {
-	case initialRecivedEvent := <-subEvents:
-		require.Equal(t, initialPublishedEvent, initialRecivedEvent)
-	case <-time.After(time.Second):
-		require.Fail(t, "timed out waiting for initial event to be recived")
-	}
+	initialRecivedEvent, found := help.ReadEvent(ctx, t, read2, subID, time.Second)
+	require.True(t, found)
+	require.Equal(t, initialPublishedEvent, initialRecivedEvent)
 
 	secondPublishedEvent := help.Event(t, help.EventOptions{PrivKey: priv, Content: "hello again"})
 	help.Publish(ctx, t, secondPublishedEvent, conn1)
 	_, found = help.GetEvent(ctx, t, secondPublishedEvent.ID, time.Second)
 	require.True(t, found)
 
-	select {
-	case secondRecivedEvent := <-subEvents:
-		require.Equal(t, secondPublishedEvent, secondRecivedEvent)
-	case <-time.After(time.Second):
-		require.Fail(t, "timed out waiting for second event to be recived")
-	}
+	secondRecivedEvent, found := help.ReadEvent(ctx, t, read2, subID, time.Second)
+	require.True(t, found)
+	require.Equal(t, secondPublishedEvent, secondRecivedEvent)
 }
 
 func TestNIP01VerificationEventID(t *testing.T) {
 	ctx := context.Background()
-	conn, closer := help.NewSocket(ctx, t)
+	conn, read, closer := help.NewSocket(ctx, t)
 	defer closer()
 
 	badEvent := help.Event(t, help.EventOptions{CreatedAt: time.Unix(1000, 0)})
@@ -275,13 +262,14 @@ func TestNIP01VerificationEventID(t *testing.T) {
 
 	subID, subCloser := help.RequestSub(ctx, t, conn, messages.Filter{IDs: []event.ID{badEvent.ID, olderevent.ID}})
 	defer subCloser()
-	found := slice.ReadSlice(help.ListenForEventsOnSub(ctx, t, conn, subID), 1, time.Second)
-	require.Equal(t, []event.ID{olderevent.ID}, slice.Map(found, func(e event.Event) event.ID { return e.ID }))
+	foundEvent, found := help.ReadEvent(ctx, t, read, subID, time.Second)
+	require.True(t, found)
+	require.Equal(t, olderevent.ID, foundEvent.ID)
 }
 
 func TestNIP01VerificationSignature(t *testing.T) {
 	ctx := context.Background()
-	conn, closer := help.NewSocket(ctx, t)
+	conn, read, closer := help.NewSocket(ctx, t)
 	defer closer()
 
 	badEvent := help.Event(t, help.EventOptions{CreatedAt: time.Unix(1000, 0)})
@@ -292,8 +280,9 @@ func TestNIP01VerificationSignature(t *testing.T) {
 
 	subID, subCloser := help.RequestSub(ctx, t, conn, messages.Filter{IDs: []event.ID{badEvent.ID, olderevent.ID}})
 	defer subCloser()
-	found := slice.ReadSlice(help.ListenForEventsOnSub(ctx, t, conn, subID), 1, time.Second)
-	require.Equal(t, []event.ID{olderevent.ID}, slice.Map(found, func(e event.Event) event.ID { return e.ID }))
+	foundEvent, found := help.ReadEvent(ctx, t, read, subID, time.Second)
+	require.True(t, found)
+	require.Equal(t, olderevent.ID, foundEvent.ID)
 }
 
 func TestNIP01DuplicateSubscriptionIDsBetweenSessions(t *testing.T) {
@@ -303,29 +292,25 @@ func TestNIP01DuplicateSubscriptionIDsBetweenSessions(t *testing.T) {
 	bytes, err := json.Marshal([]interface{}{"REQ", subID, messages.Filter{IDs: []event.ID{eventSent.ID}}})
 	require.NoError(t, err)
 
-	conn1, closer1 := help.NewSocket(ctx, t)
+	conn1, read1, closer1 := help.NewSocket(ctx, t)
 	defer closer1()
 	require.NoError(t, conn1.Write(ctx, websocket.MessageText, bytes))
 
-	conn2, closer2 := help.NewSocket(ctx, t)
+	conn2, read2, closer2 := help.NewSocket(ctx, t)
 	defer closer2()
 	require.NoError(t, conn2.Write(ctx, websocket.MessageText, bytes))
 
-	conn3, closer3 := help.NewSocket(ctx, t)
+	conn3, _, closer3 := help.NewSocket(ctx, t)
 	defer closer3()
 	help.Publish(ctx, t, eventSent, conn3)
-	select {
-	case e := <-help.ListenForEventsOnSub(ctx, t, conn1, messages.SubscriptionID(subID)):
-		require.Equal(t, eventSent.ID, e.ID)
-	case <-time.After(time.Second):
-		require.Fail(t, "timed out waiting for event")
-	}
-	select {
-	case e := <-help.ListenForEventsOnSub(ctx, t, conn2, messages.SubscriptionID(subID)):
-		require.Equal(t, eventSent.ID, e.ID)
-	case <-time.After(time.Second):
-		require.Fail(t, "timed out waiting for event")
-	}
+
+	e, found := help.ReadEvent(ctx, t, read1, messages.SubscriptionID(subID), time.Second)
+	require.True(t, found)
+	require.Equal(t, eventSent.ID, e.ID)
+
+	e, found = help.ReadEvent(ctx, t, read2, messages.SubscriptionID(subID), time.Second)
+	require.True(t, found)
+	require.Equal(t, eventSent.ID, e.ID)
 }
 
 func TestNIP01DuplicateSubscriptionIDsBetweenSessionsClosing(t *testing.T) {
@@ -335,24 +320,21 @@ func TestNIP01DuplicateSubscriptionIDsBetweenSessionsClosing(t *testing.T) {
 	bytes, err := json.Marshal([]interface{}{"REQ", subID, messages.Filter{IDs: []event.ID{eventSent.ID}}})
 	require.NoError(t, err)
 
-	conn1, closer1 := help.NewSocket(ctx, t)
+	conn1, read1, closer1 := help.NewSocket(ctx, t)
 	defer closer1()
 	require.NoError(t, conn1.Write(ctx, websocket.MessageText, bytes))
 
-	conn2, closer2 := help.NewSocket(ctx, t)
+	conn2, _, closer2 := help.NewSocket(ctx, t)
 	defer closer2()
 	require.NoError(t, conn2.Write(ctx, websocket.MessageText, bytes))
 
 	help.CloseSubscription(ctx, t, subID, conn2)
 
-	conn3, closer3 := help.NewSocket(ctx, t)
+	conn3, _, closer3 := help.NewSocket(ctx, t)
 	defer closer3()
 	help.Publish(ctx, t, eventSent, conn3)
 
-	select {
-	case e := <-help.ListenForEventsOnSub(ctx, t, conn1, subID):
-		require.Equal(t, eventSent.ID, e.ID)
-	case <-time.After(time.Second):
-		require.Fail(t, "timed out waiting for event")
-	}
+	e, found := help.ReadEvent(ctx, t, read1, subID, time.Second)
+	require.True(t, found)
+	require.Equal(t, eventSent.ID, e.ID)
 }

--- a/test/component/nip01_test.go
+++ b/test/component/nip01_test.go
@@ -192,6 +192,8 @@ func TestNIP01Filters(t *testing.T) {
 			defer closer()
 			for _, e := range tc.allEvents {
 				help.Publish(ctx, t, e, conn)
+				_, found := help.GetEvent(ctx, t, e.ID, time.Second)
+				require.True(t, found, "event in setup not found after publishing it")
 			}
 			expectedRecivedEventsIDs := make([]event.ID, len(tc.recivedEventsAtIndices))
 			for i, index := range tc.recivedEventsAtIndices {
@@ -232,7 +234,7 @@ func TestNIP01GetEventsAfterInitialSync(t *testing.T) {
 	defer closer1()
 	initialPublishedEvent := help.Event(t, help.EventOptions{PrivKey: priv, Content: "hello world"})
 	help.Publish(ctx, t, initialPublishedEvent, conn1)
-	_, found := help.GetEvent(ctx, t, conn1, initialPublishedEvent.ID, time.Second)
+	_, found := help.GetEvent(ctx, t, initialPublishedEvent.ID, time.Second)
 	require.True(t, found)
 
 	conn2, closer2 := help.NewSocket(ctx, t)
@@ -249,7 +251,7 @@ func TestNIP01GetEventsAfterInitialSync(t *testing.T) {
 
 	secondPublishedEvent := help.Event(t, help.EventOptions{PrivKey: priv, Content: "hello again"})
 	help.Publish(ctx, t, secondPublishedEvent, conn1)
-	_, found = help.GetEvent(ctx, t, conn1, secondPublishedEvent.ID, time.Second)
+	_, found = help.GetEvent(ctx, t, secondPublishedEvent.ID, time.Second)
 	require.True(t, found)
 
 	select {


### PR DESCRIPTION
From the [websocket library documentation](https://pkg.go.dev/nhooyr.io/websocket#Conn)

> You must always read from the connection. Otherwise control frames will  not be handled